### PR TITLE
remove memory ballooning

### DIFF
--- a/services/kubernetes/pulumi/Pulumi.prod.yaml
+++ b/services/kubernetes/pulumi/Pulumi.prod.yaml
@@ -10,9 +10,9 @@ config:
         - name: k8s-master-0
           vmid: 120
           ipv4-address: 10.0.10.2/24
-          cores: 2
-          memory_mb_min: 2048
-          memory_mb_max: 10140
+          cores: 3
+          memory_mb_min: 6144
+          memory_mb_max: 6144
           root_disk_size_gb: 64
           data_disk_size_gb: 256
       ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINkV2VImBNPnGv5kyC9ybGPhMipr0VhFe1n/Ks7Sm8k4 mpagel@k8s-prod


### PR DESCRIPTION
Memory pressure on host >= 80% leads to ballooning, such that k8s VM was left with 2 GB only. k8s could not longer run applications, whcih were terminated and restarted in a loop.