### PR TITLE
allow rclone sync to multiple remotes

### DIFF
--- a/services/paperless/pulumi/Pulumi.prod-juno.yaml
+++ b/services/paperless/pulumi/Pulumi.prod-juno.yaml
@@ -23,4 +23,5 @@ config:
       version: v1.69.3
       rclone-conf-b64:
         envvar: RCLONE_CONF_B64__ONEDRIVE__TOM
-      destination: "onedrive:Paperless"
+      destinations:
+        - "onedrive:Paperless"

--- a/services/paperless/pulumi/Pulumi.prod.yaml
+++ b/services/paperless/pulumi/Pulumi.prod.yaml
@@ -21,6 +21,7 @@ config:
       # renovate: datasource=github-releases packageName=rclone/rclone versioning=semver
       version: v1.69.3
       rclone-conf-b64:
-        envvar: RCLONE_CONF_B64__ONEDRIVE__MIKE
+        envvar: RCLONE_CONF_B64__PAPERLESS
       destinations:
-        - "onedrive:Paperless"
+        - "onedrive-mike:Paperless"
+        - "onedrive-britta:Paperless"

--- a/services/paperless/pulumi/Pulumi.prod.yaml
+++ b/services/paperless/pulumi/Pulumi.prod.yaml
@@ -22,4 +22,5 @@ config:
       version: v1.69.3
       rclone-conf-b64:
         envvar: RCLONE_CONF_B64__ONEDRIVE__MIKE
-      destination: "onedrive:Paperless"
+      destinations:
+        - "onedrive:Paperless"

--- a/services/paperless/pulumi/assets/rclone-sync.sh
+++ b/services/paperless/pulumi/assets/rclone-sync.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+mkdir -p {{ rclone_config_dir_write }}
+cat {{ rclone_config_dir_readonly }}/{{ rclone_config_file_name }} > {{ rclone_config_dir_write }}/{{ rclone_config_file_name }}
+
+while true; do
+  echo *********************************************************************************************
+  set -x
+  rclone sync {{ rclone_media_mount }}/documents/originals {{ destination }} --config {{ rclone_config_dir_write }}/{{ rclone_config_file_name }} -v
+  set +x
+  sleep {{ sync_period_sec }}
+done

--- a/services/paperless/pulumi/assets/rclone-sync.sh
+++ b/services/paperless/pulumi/assets/rclone-sync.sh
@@ -5,7 +5,9 @@ cat {{ rclone_config_dir_readonly }}/{{ rclone_config_file_name }} > {{ rclone_c
 while true; do
   echo *********************************************************************************************
   set -x
+{%- for destination in destinations %}
   rclone sync {{ rclone_media_mount }}/documents/originals {{ destination }} --config {{ rclone_config_dir_write }}/{{ rclone_config_file_name }} -v
+{%- endfor %}
   set +x
   sleep {{ sync_period_sec }}
 done

--- a/services/paperless/pulumi/paperless/model.py
+++ b/services/paperless/pulumi/paperless/model.py
@@ -32,8 +32,8 @@ class RCloneConfig(ConfigBaseModel):
     version: str
     rclone_conf_b64: EnvVarRef
     """Base64 encoded rclone config file, including remote and refresh token."""
-    destination: str
     sync_period_sec: pydantic.PositiveInt = 600
+    destinations: list[str]
 
 
 class ComponentConfig(ConfigBaseModel):

--- a/services/paperless/pyproject.toml
+++ b/services/paperless/pyproject.toml
@@ -7,4 +7,5 @@ dependencies = [
     "pulumi-kubernetes>=4.21.0",
     "pulumi-random>=4.18.0",
     "pydantic>=2.10.1",
+    "jinja2>=3.1.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -566,6 +566,7 @@ name = "paperless"
 version = "0.1.0"
 source = { virtual = "services/paperless" }
 dependencies = [
+    { name = "jinja2" },
     { name = "pulumi" },
     { name = "pulumi-kubernetes" },
     { name = "pulumi-random" },
@@ -574,6 +575,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "jinja2", specifier = ">=3.1.4" },
     { name = "pulumi", specifier = ">=3.147.0" },
     { name = "pulumi-kubernetes", specifier = ">=4.21.0" },
     { name = "pulumi-random", specifier = ">=4.18.0" },


### PR DESCRIPTION
Onedrive has an issue for over one year preventing shared folders to be reliably linked into the consuming user's folder hierarchy. To still be able to access original documents from Onedrive, synchronize to all users' Oncedrive folders explicitly.