### PR TITLE
Revert "Update dependency redis/redis to v8.0.3"

### DIFF
--- a/services/paperless/pulumi/Pulumi.dev.yaml
+++ b/services/paperless/pulumi/Pulumi.dev.yaml
@@ -11,7 +11,7 @@ config:
       exporter-kubectl-version: 1.33.1
     redis:
       # renovate: datasource=github-releases packageName=redis/redis versioning=semver
-      version: 8.0.3
+      version: 8.0.2
     entraid:
       client-id: de687424-284e-4aeb-b100-b7c6caa11346
       client-secret:

--- a/services/paperless/pulumi/Pulumi.prod-juno.yaml
+++ b/services/paperless/pulumi/Pulumi.prod-juno.yaml
@@ -13,7 +13,7 @@ config:
       external-hostname: paperless-juno.mpagel.de
     redis:
       # renovate: datasource=github-releases packageName=redis/redis versioning=semver
-      version: 8.0.3
+      version: 8.0.2
     entraid:
       client-id: bb005af2-2cc0-49a8-9e2e-923e8869e369
       client-secret:

--- a/services/paperless/pulumi/Pulumi.prod.yaml
+++ b/services/paperless/pulumi/Pulumi.prod.yaml
@@ -12,7 +12,7 @@ config:
       exporter-kubectl-version: 1.33.1
     redis:
       # renovate: datasource=github-releases packageName=redis/redis versioning=semver
-      version: 8.0.3
+      version: 8.0.2
     entraid:
       client-id: 89f2baa9-6e88-4a00-8c06-f6151b0b921b
       client-secret:


### PR DESCRIPTION
Reverts CrashLoopBackCoffee/mp-deploy-homelab#91

8.0.3 cannot be pulled yet