### PR TITLE
add playbook for kernel extras install

### DIFF
--- a/services/kubernetes/ansible/playbooks/install-kernel-modules-extra.yaml
+++ b/services/kubernetes/ansible/playbooks/install-kernel-modules-extra.yaml
@@ -1,0 +1,15 @@
+---
+- name: Install Linux modules extra package
+  hosts: all
+  become: true
+  gather_facts: true
+
+  tasks:
+    - name: Install kernel modules extra and UTF-8 support
+      ansible.builtin.apt:
+        name:
+          - linux-modules-extra-{{ ansible_kernel }}
+          - locales
+        state: present
+        update_cache: true
+      when: ansible_os_family == "Debian"


### PR DESCRIPTION
To make the Samba/CIFS CSI driver work, the kernel extras package must
be installed. This has to be done after each kernel update.

For now I voted against adding a postinstall hook script to the node as
this is more visible (but also more manual).
